### PR TITLE
Remove oh-my-zsh installation and config

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -21,6 +21,3 @@ alias ...='cd ../..'
 
 # Enable color support
 autoload -U colors && colors
-
-export ZSH="$HOME/.oh-my-zsh"
-source $ZSH/oh-my-zsh.sh

--- a/install.sh
+++ b/install.sh
@@ -33,9 +33,4 @@ if [ "$SHELL" != "/bin/zsh" ]; then
     chsh -s /bin/zsh || true
 fi
 
-# Install oh-my-zsh
-if [ ! -d "$HOME/.oh-my-zsh" ]; then
-  sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended --keep-zshrc
-fi
-
 echo "Dotfiles installation complete!"


### PR DESCRIPTION
Removes oh-my-zsh from install.sh and the related export/source lines from .zshrc.

Made with [Cursor](https://cursor.com)