### PR TITLE
feat: add Oh My Zsh installation

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,9 @@
+# Oh My Zsh configuration
+export ZSH="$HOME/.oh-my-zsh"
+ZSH_THEME="robbyrussell"
+plugins=(git docker kubectl npm history)
+source $ZSH/oh-my-zsh.sh
+
 # History search with Ctrl+p/n
 bindkey '^P' history-beginning-search-backward
 bindkey '^N' history-beginning-search-forward

--- a/install.sh
+++ b/install.sh
@@ -172,6 +172,10 @@ sudo apt-get install -y \
   wget \
   unzip
 
+# Install Oh My Zsh (non-interactive, keep existing .zshrc)
+log "Installing Oh My Zsh..."
+RUNZSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" || true
+
 # Install yq
 log "Installing yq..."
 sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64


### PR DESCRIPTION
## Summary

- Install Oh My Zsh after apt packages using `KEEP_ZSHRC=yes` to preserve the custom `.zshrc` symlink
- Configure `.zshrc` to source Oh My Zsh with `robbyrussell` theme
- Enable bundled plugins: `git`, `docker`, `kubectl`, `npm`, `history`

## Test plan

- [ ] Rebuild a Coder workspace
- [ ] Verify Oh My Zsh is installed (`ls ~/.oh-my-zsh`)
- [ ] Verify `.zshrc` is still a symlink to dotfiles repo
- [ ] Open terminal and confirm oh-my-zsh theme/prompt appears
- [ ] Verify custom keybindings still work (Ctrl+P for history search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)