### PR TITLE
fix: run oh-my-zsh installer from $HOME to avoid git context issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -173,8 +173,9 @@ sudo apt-get install -y \
   unzip
 
 # Install Oh My Zsh (non-interactive, keep existing .zshrc)
+# Run from $HOME to avoid git context issues with the dotfiles repo
 log "Installing Oh My Zsh..."
-RUNZSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" || true
+(cd "$HOME" && RUNZSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)") || true
 
 # Install yq
 log "Installing yq..."


### PR DESCRIPTION
## Summary

- Fixes Oh My Zsh installation failing with `fatal: not in a git directory` error
- The installer was running inside the dotfiles repo context, causing git operations to fail
- Wraps the install command in a subshell that first changes to `$HOME` to escape the git context

## Test plan

- [ ] Rebuild a Coder workspace
- [ ] Verify Oh My Zsh is installed (`ls ~/.oh-my-zsh`)
- [ ] Verify `.zshrc` is still a symlink to dotfiles repo
- [ ] Open terminal and confirm oh-my-zsh theme/prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)