### PR TITLE
fix: unset git env vars before oh-my-zsh install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -173,9 +173,9 @@ sudo apt-get install -y \
   unzip
 
 # Install Oh My Zsh (non-interactive, keep existing .zshrc)
-# Run from $HOME to avoid git context issues with the dotfiles repo
+# Run from $HOME and unset git env vars to avoid context issues with the dotfiles repo
 log "Installing Oh My Zsh..."
-(cd "$HOME" && RUNZSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)") || true
+(cd "$HOME" && unset GIT_DIR GIT_WORK_TREE && RUNZSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)") || true
 
 # Install yq
 log "Installing yq..."


### PR DESCRIPTION
## Summary

- Fixes intermittent Oh My Zsh installation failure with `fatal: not in a git directory`
- The previous fix (`cd $HOME`) wasn't sufficient because git environment variables (`GIT_DIR`, `GIT_WORK_TREE`) persist even after changing directories
- Adding `unset GIT_DIR GIT_WORK_TREE` ensures the installer runs in a clean git context

## Test plan

- [ ] Rebuild a Coder workspace
- [ ] Verify Oh My Zsh is installed (`ls ~/.oh-my-zsh`)
- [ ] Verify `.zshrc` is still a symlink to dotfiles repo
- [ ] Open terminal and confirm oh-my-zsh theme/prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)