### PR TITLE
fix: add safe.directory to gitconfig for Coder workspaces

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -13,3 +13,5 @@
     defaultBranch = main
 [pull]
     rebase = true
+[safe]
+    directory = *


### PR DESCRIPTION
## Summary

- Adds `[safe] directory = *` to `.gitconfig`
- Fixes git "dubious ownership" errors in Coder workspaces
- Restores oh-my-zsh git prompt showing branch info

## Root cause

Coder workspaces can have file ownership mismatches between the container user and the mounted files. Git's security check blocks commands with "dubious ownership" errors, which breaks:
- Normal git operations
- The oh-my-zsh `git_prompt_info` function (no branch shown in prompt)

The `safe.directory = *` setting was being set in main.tf, but the dotfiles symlink overwrites `.gitconfig`, losing that setting.

## Test plan

- [ ] Rebuild a Coder workspace
- [ ] Verify git commands work: `git status`
- [ ] Verify oh-my-zsh prompt shows branch: `➜ dir git:(main)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)