### PR TITLE
feat: add kubectl alias (k)

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -27,6 +27,7 @@ alias la='ls -A'
 alias l='ls -CF'
 alias ..='cd ..'
 alias ...='cd ../..'
+alias k='kubectl'
 
 # Enable color support
 autoload -U colors && colors


### PR DESCRIPTION
## Summary
- Adds `alias k='kubectl'` to `.zshrc` for quicker Kubernetes CLI access

## Test plan
- [ ] Source `.zshrc` and verify `k get pods` works the same as `kubectl get pods`

🤖 Generated with [Claude Code](https://claude.com/claude-code)