### PR TITLE
feat: symlink agent-config settings.json and skills/

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -169,10 +169,10 @@ else
 fi
 
 # ------------------------------------------------------------
-# 4b) Claude Code user-level rules from agent-config repo
+# 4b) Claude Code user-level config from agent-config repo (rules, settings, skills)
 # ------------------------------------------------------------
 AGENT_CONFIG_DIR="$HOME/.agent-config"
-log "Setting up Claude Code user-level rules from agent-config..."
+log "Setting up Claude Code user-level config from agent-config..."
 if [ -d "$AGENT_CONFIG_DIR/.git" ]; then
   log "agent-config already cloned; pulling latest..."
   git -C "$AGENT_CONFIG_DIR" pull --ff-only origin main || true
@@ -188,6 +188,20 @@ else
   backup_if_needed "$HOME/.claude/rules"
   ln -s "$AGENT_CONFIG_DIR/rules" "$HOME/.claude/rules"
   log "Linked ~/.claude/rules -> $AGENT_CONFIG_DIR/rules"
+fi
+if [ -L "$HOME/.claude/settings.json" ] && [ "$(readlink "$HOME/.claude/settings.json")" = "$AGENT_CONFIG_DIR/settings.json" ]; then
+  log "Settings symlink already correct"
+else
+  backup_if_needed "$HOME/.claude/settings.json"
+  ln -s "$AGENT_CONFIG_DIR/settings.json" "$HOME/.claude/settings.json"
+  log "Linked ~/.claude/settings.json -> $AGENT_CONFIG_DIR/settings.json"
+fi
+if [ -L "$HOME/.claude/skills" ] && [ "$(readlink "$HOME/.claude/skills")" = "$AGENT_CONFIG_DIR/skills" ]; then
+  log "Skills symlink already correct"
+else
+  backup_if_needed "$HOME/.claude/skills"
+  ln -s "$AGENT_CONFIG_DIR/skills" "$HOME/.claude/skills"
+  log "Linked ~/.claude/skills -> $AGENT_CONFIG_DIR/skills"
 fi
 
 # ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds symlink blocks for `~/.claude/settings.json` and `~/.claude/skills` in `install.sh`, following the existing `rules` pattern
- Updates section header and log message to reflect the broader scope (rules, settings, skills)
- Each new block is idempotent: checks if the symlink already points to the correct target before acting

## Test plan
- [ ] Run `bash -n install.sh` (pre-existing heredoc `case` triggers a false positive — actual execution is unaffected)
- [ ] Run `install.sh` on a fresh Coder workspace and verify all three symlinks are created under `~/.claude/`
- [ ] Run `install.sh` again and verify idempotent "already correct" log messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)